### PR TITLE
Add newline workaround

### DIFF
--- a/data/public.snmprec
+++ b/data/public.snmprec
@@ -1,4 +1,4 @@
-1.3.6.1.2.1.1.1.0|4|Linux zeus 4.8.6.5-smp #2 SMP Sun Nov 13 14:58:11 CDT 2016 i686
+1.3.6.1.2.1.1.1.0|4|Linux zeus 4.8.6.5-smp #2 SMP Sun Nov 13 14:58:11 CDT 2016 i686<---NEWLINE--->New line workaround sample
 1.3.6.1.2.1.1.2.0|6|1.3.6.1.4.1.8072.3.2.10
 1.3.6.1.2.1.1.3.0|67:numeric|rate=100,initial=123999999
 1.3.6.1.2.1.1.4.0|4|SNMP Laboratories, info@snmplabs.com

--- a/snmpsim/grammar/snmprec.py
+++ b/snmpsim/grammar/snmprec.py
@@ -11,6 +11,8 @@ from pyasn1.type import univ
 from snmpsim.grammar.abstract import AbstractGrammar
 from snmpsim import error
 
+NEWLINE = "<---NEWLINE--->"
+
 
 class SnmprecGrammar(AbstractGrammar):
     alnums = set(octs2ints(str2octs(ascii_letters + digits)))
@@ -38,6 +40,7 @@ class SnmprecGrammar(AbstractGrammar):
     def parse(self, line):
         try:
             oid, tag, value = octs2str(line).strip().split('|', 2)
+            value = value.replace(NEWLINE, "\n")
         except:
             raise error.SnmpsimError('broken record <%s>' % line)
         else:


### PR DESCRIPTION
<---NEWLINE---> will be replaced to \n

<img width="847" alt="alacritty 2019-02-25 12-33-24" src="https://user-images.githubusercontent.com/546312/53312748-9f2c3f00-38f9-11e9-92b7-375aa8de49c4.png">

```
1.3.6.1.2.1.1.1.0|4|Linux zeus 4.8.6.5-smp #2 SMP Sun Nov 13 14:58:11 CDT 2016 i686<---NEWLINE--->New line workaround sample
1.3.6.1.2.1.1.2.0|6|1.3.6.1.4.1.8072.3.2.10
1.3.6.1.2.1.1.3.0|67:numeric|rate=100,initial=123999999
```